### PR TITLE
Delete php7.2-mcrypt package

### DIFF
--- a/bash-scripts/16.04/install-nginx1.10-php7.2.sh
+++ b/bash-scripts/16.04/install-nginx1.10-php7.2.sh
@@ -29,8 +29,8 @@ if ! grep -q "$PHP7_PPA" /etc/apt/sources.list /etc/apt/sources.list.d/*; then
     sudo apt-get update;
 fi
 
-apt_get_packages=( "git" "zip" "php7.2-fpm" "php7.2-mysql" "php7.2-gd" "php7.2-cli" "php7.2-common" "php7.2-json" "php7.2-curl" "php7.2-mcrypt" "php7.2-readline" "php-mongodb" "php-redis" "php7.2-sqlite" "php7.2-bcmath" "php7.2-mbstring" "php7.2-zip" "php7.2-xml" "php7.2-intl" "php-imagick"); # "python-pip"
-# php7.2 php7.2-fpm php7.2-mysql php7.2-cli php7.2-common php7.2-curl php7.2-gd php7.2-json php7.2-mcrypt php7.2-readline
+apt_get_packages=( "git" "zip" "php7.2-fpm" "php7.2-mysql" "php7.2-gd" "php7.2-cli" "php7.2-common" "php7.2-json" "php7.2-curl" "php7.2-readline" "php-mongodb" "php-redis" "php7.2-sqlite" "php7.2-bcmath" "php7.2-mbstring" "php7.2-zip" "php7.2-xml" "php7.2-intl" "php-imagick"); # "python-pip"
+# php7.2 php7.2-fpm php7.2-mysql php7.2-cli php7.2-common php7.2-curl php7.2-gd php7.2-json php7.2-readline
 # api: php5-memcached php5-mongo php5-redis
 for i in "${!apt_get_packages[@]}"; do
     if [ $(dpkg-query -W -f='${Status}' "${apt_get_packages[$i]}" 2>/dev/null | grep -c "ok installed") -eq 0 ];


### PR DESCRIPTION
It's removed in PHP 7.2.0.
Read more: [PHP official document](http://php.net/manual/en/intro.mcrypt.php)